### PR TITLE
added name tag to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <artifactId>aerogear-misc</artifactId>
     <version>0.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <name>Artifact used across Aerogear projects for common Maven builds</name>
+    <name>Artifact used across AeroGear projects for common Maven builds</name>
 
     <parent>
         <groupId>org.jboss</groupId>


### PR DESCRIPTION
@matzew  it is added here solely for making our internal validators quiet (1) when we are doing AeroGear productization and complying with the best practices.

(1) https://github.com/thradec/wolf-validator
